### PR TITLE
Docker build fails when UpperCase chars exist in username/repo

### DIFF
--- a/docker-gpr/main.js
+++ b/docker-gpr/main.js
@@ -5,8 +5,8 @@ async function run() {
   try {
     const token = core.getInput("repo-token");
     const username = process.env.GITHUB_ACTOR;
-    const imageName = core.getInput("image-name");
-    const githubRepo = process.env.GITHUB_REPOSITORY;
+    const imageName = core.getInput("image-name").toLowerCase();
+    const githubRepo = process.env.GITHUB_REPOSITORY.toLowerCase();
     const tag = process.env.GITHUB_SHA;
 
     await exec.exec(


### PR DESCRIPTION
Resolves error:
> `invalid argument "docker.pkg.github.com/UpperCaseUser/repo/..." for "-t, --tag" flag: invalid reference format: repository name must be lowercase`