### PR TITLE
Merging v1 branch to master 

### DIFF
--- a/docker-gpr/README.md
+++ b/docker-gpr/README.md
@@ -1,0 +1,56 @@
+# Docker-GPR 🐳
+
+A GitHub Action to upload Docker images to the GitHub Package Registry.  
+
+**For this Action to work you need to have [access to GPR](https://github.com/features/package-registry)**
+
+## Usage
+
+### Action Options:
+
+|Parameter|Description|Default Value|Required|
+|:---:|---|---|:---:|
+|`repo-token`|Access token allowing authentication to the GitHub API.  `GITHUB_TOKEN` is recommended.|No token was supplied... now you know why things broke!|:white_check_mark:|
+|`image-name`|Desired name for your Docker image||:white_check_mark:|
+
+
+See the [action.yml](https://github.com/mattdavis0351/actions/blob/master/docker-gpr/action.yml) for further information about this Action.
+
+---
+
+### Examples:
+
+**Basic Usage**
+```yaml
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build, Tag, Push
+        uses: mattdavis0351/actions/docker-gpr@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          image-name: tic-tac-toe
+```
+
+---
+
+### After This Action Runs
+
+Along your repository navigation bar you should see that you now have at least one package:
+
+![GitHub repository package count](https://i.imgur.com/gfphpUH.png)
+
+Inside of that tab you will find all of the packages associated with this repository as well as meta-data about them:
+
+![GitHub Package Information](https://i.imgur.com/L2sBQz5.png)
+
+As we can see here we have a Docker image named `tic-tac-toe` with a tag of `f29`.  The tag is comprised of the last three digits from the `COMMIT_SHA`.
+
+Clicking the title of your package will take you to the usage screen below: 
+
+![package usage instructions](https://i.imgur.com/uku0eZk.png)
+
+Follow these instructions to pull your newly uploaded Docker image.
+
+

--- a/docker-gpr/README.md
+++ b/docker-gpr/README.md
@@ -12,6 +12,7 @@ A GitHub Action to upload Docker images to the GitHub Package Registry.
 |:---:|---|---|:---:|
 |`repo-token`|Access token allowing authentication to the GitHub API.  `GITHUB_TOKEN` is recommended.|No token was supplied... now you know why things broke!|:white_check_mark:|
 |`image-name`|Desired name for your Docker image||:white_check_mark:|
+|`dockerfile-location`|The location in the repo where the Dockerfile is|.||
 
 
 See the [action.yml](https://github.com/mattdavis0351/actions/blob/master/docker-gpr/action.yml) for further information about this Action.
@@ -32,6 +33,21 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           image-name: tic-tac-toe
 ```
+
+```yaml
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build, Tag, Push
+        uses: mattdavis0351/actions/docker-gpr@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          image-name: tic-tac-toe
+          dockerfile-location: dir/test
+```
+
+
 
 ---
 

--- a/docker-gpr/action.yml
+++ b/docker-gpr/action.yml
@@ -4,6 +4,7 @@ description: Build, Tag and Push images from a Dockerfile to the GPR
 inputs:
   repo-token:
     description: Access token to use the api, use GITHUB_TOKEN silly, it's better
+    default: No token was supplied... now you know why things broke!
     required: true
   image-name:
     description: name for Docker image-name

--- a/docker-gpr/action.yml
+++ b/docker-gpr/action.yml
@@ -9,6 +9,10 @@ inputs:
   image-name:
     description: name for Docker image-name
     required: true
+  dockerfile-location:
+    description: Where in the repo the Dockerfile is located
+    default: .
+    required: false
 
 runs:
   using: "node12"

--- a/docker-gpr/main.js
+++ b/docker-gpr/main.js
@@ -4,6 +4,7 @@ const core = require("@actions/core");
 async function run() {
   try {
     const token = core.getInput("repo-token");
+    const dockerfileLocation = core.getInput("dockerfile-location");
     const username = process.env.GITHUB_ACTOR;
     const imageName = core.getInput("image-name").toLowerCase();
     const githubRepo = process.env.GITHUB_REPOSITORY.toLowerCase();
@@ -15,7 +16,7 @@ async function run() {
     await exec.exec(
       `docker build -t docker.pkg.github.com/${githubRepo}/${imageName}:${tag.slice(
         tag.length - 3
-      )} .`
+      )} ${dockerfileLocation}`
     );
     await exec.exec(
       `docker push docker.pkg.github.com/${githubRepo}/${imageName}:${tag.slice(

--- a/docker-gpr/main.js
+++ b/docker-gpr/main.js
@@ -5,8 +5,8 @@ async function run() {
   try {
     const token = core.getInput("repo-token");
     const username = process.env.GITHUB_ACTOR;
-    const imageName = core.getInput("image-name");
-    const githubRepo = process.env.GITHUB_REPOSITORY;
+    const imageName = core.getInput("image-name").toLowerCase();
+    const githubRepo = process.env.GITHUB_REPOSITORY.toLowerCase();
     const tag = process.env.GITHUB_SHA;
 
     await exec.exec(


### PR DESCRIPTION
Instead of targeting a branch, a better practice is for this to be tagged as a release.  This PR places the most up to date Actions code into a state that works better for release