### PR TITLE
Add tag input to docker-gpr action

### DIFF
--- a/docker-gpr/README.md
+++ b/docker-gpr/README.md
@@ -12,7 +12,8 @@ A GitHub Action to upload Docker images to the GitHub Package Registry.
 |:---:|---|---|:---:|
 |`repo-token`|Access token allowing authentication to the GitHub API.  `GITHUB_TOKEN` is recommended.|No token was supplied... now you know why things broke!|:white_check_mark:|
 |`image-name`|Desired name for your Docker image||:white_check_mark:|
-|`dockerfile-location`|The location in the repo where the Dockerfile is|.||
+|`dockerfile-location`|The location in the repo where the Dockerfile is|.|
+|`tag`|Desired tag for your Docker image.|`COMMIT_SHA`||
 
 
 See the [action.yml](https://github.com/mattdavis0351/actions/blob/master/docker-gpr/action.yml) for further information about this Action.
@@ -45,6 +46,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           image-name: tic-tac-toe
           dockerfile-location: dir/test
+          tag: latest
 ```
 
 
@@ -61,7 +63,7 @@ Inside of that tab you will find all of the packages associated with this reposi
 
 ![GitHub Package Information](https://i.imgur.com/L2sBQz5.png)
 
-As we can see here we have a Docker image named `tic-tac-toe` with a tag of `f29`.  The tag is comprised of the last three digits from the `COMMIT_SHA`.
+As we can see here we have a Docker image named `tic-tac-toe` with a tag of `f29`.
 
 Clicking the title of your package will take you to the usage screen below: 
 

--- a/docker-gpr/action.yml
+++ b/docker-gpr/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: Where in the repo the Dockerfile is located
     default: .
     required: false
+  tag:
+    description: tag for Docker image
+    default: ${{ github.sha }}
+    required: false
     
 outputs:
   imageUrl:

--- a/docker-gpr/main.js
+++ b/docker-gpr/main.js
@@ -7,7 +7,7 @@ async function run() {
   const username = process.env.GITHUB_ACTOR;
   const imageName = core.getInput("image-name").toLowerCase();
   const githubRepo = process.env.GITHUB_REPOSITORY.toLowerCase();
-  const tag = process.env.GITHUB_SHA;
+  const tag = core.getInput("tag").toLowerCase();
   const fullImageReference = `docker.pkg.github.com/${githubRepo}/${imageName}:${tag}`;
   try {
     await exec.exec(


### PR DESCRIPTION
This adds an additional input to the docker-gpr action that allows users to define the tag of the image that is built and pushed.
This is backwards compatible as it defaults to `COMMIT_SHA`.
This PR also fixes the README that still described old behavior where the tag was only the last three digits of `COMMIT_SHA`.
This allows users to for example always push their images as `latest` or use other action's output as the tag.